### PR TITLE
Update legacy facilities and servers

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,7 @@ variable "auth_token" {
 variable "facility" {
   type        = string
   description = "Equinix Metal Facility"
-  default     = "ewr1"
+  default     = "dc13"
 }
 
 variable "project_id" {
@@ -17,13 +17,13 @@ variable "project_id" {
 variable "plan_arm" {
   type        = string
   description = "Plan for K8s ARM Nodes"
-  default     = "baremetal_2a"
+  default     = "c1.large.arm"
 }
 
 variable "plan_x86" {
   type        = string
   description = "Plan for K8s x86 Nodes"
-  default     = "c1.small.x86"
+  default     = "c3.small.x86"
 }
 
 variable "plan_gpu" {
@@ -35,7 +35,7 @@ variable "plan_gpu" {
 variable "plan_primary" {
   type        = string
   description = "K8s Primary Plan (Defaults to x86 - baremetal_0)"
-  default     = "c1.small.x86"
+  default     = "c3.small.x86"
 }
 
 variable "cluster_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -34,7 +34,7 @@ variable "plan_gpu" {
 
 variable "plan_primary" {
   type        = string
-  description = "K8s Primary Plan (Defaults to x86 - baremetal_0)"
+  description = "K8s Primary Plan"
   default     = "c3.small.x86"
 }
 


### PR DESCRIPTION
[SIG onprem](https://github.com/kubeflow-onprem/terraform-metal-multiarch-k8s/) from [Kubeflow](https://www.kubeflow.org/) is using this repo to deploy Equinix Metal servers and Kubernetes. I've found a couple issues when using the code from this repo on a new Equinix Metal account with no hardware reservations or access to ARM servers:

* "ewr1" is only available through a [hardware reservation](https://metal.equinix.com/developers/docs/locations/facilities/#expansion-sites). To accommodate user accounts without hardware reservations, it would be better to use something like "dc13" instead.
```
╷
│ Error: Error reserving IP address block: POST https://api.equinix.com/metal/v1/projects/d2bb6d34-9d18-4934-aaa4-a70c144d0864/ips: 422 ewr1 is not a valid facility 
│ 
│   on kubernetes-controller-pool.tf line 31, in resource "metal_reserved_ip_block" "kubernetes":
│   31: resource "metal_reserved_ip_block" "kubernetes" {
```

* "c1.small.x86" is a [legacy device that uses RAID1](https://metal.equinix.com/developers/docs/servers/custom-partitioning-raid/#legacy-gen-1-gen-2-devices). Updating to "c3.small.x86", should work better for a wider range of users.

* [ARM servers are not available by default](https://metal.equinix.com/developers/docs/servers/#arm-servers). To accommodate user accounts without access to ARM servers I would recommend removing all the Terraform code related to ARM or setting the default count to 0 as it will throw an error about ARM not being available. If you do plan on using ARM use "c1.large.arm" instead as that is more up-to-date.

```
╷
│ Error: You are not allowed to provision c1.large.arm servers
│
│   on modules/node_pool/main.tf line 25, in resource "metal_device" "arm_node":
│   25: resource "metal_device" "arm_node" {
│
╵
╷
│ Error: You are not allowed to provision c1.large.arm servers
│
│   on modules/node_pool/main.tf line 25, in resource "metal_device" "arm_node":
│   25: resource "metal_device" "arm_node" {
│
╵
╷
│ Error: You are not allowed to provision c1.large.arm servers
│
│   on modules/node_pool/main.tf line 25, in resource "metal_device" "arm_node":
│   25: resource "metal_device" "arm_node" {
│
╵
```
Also, I noticed [all of the GPU server types are legacy](https://metal.equinix.com/developers/docs/servers/#legacy-servers). What the future plans are for GPU server types?

_Originally https://github.com/kubeflow-onprem/terraform-metal-multiarch-k8s/pull/1_