### PR TITLE
Updates node_pool to use kubeconfig on control plane node to delete n…

### DIFF
--- a/kubernetes-node-pool.tf
+++ b/kubernetes-node-pool.tf
@@ -1,31 +1,33 @@
 module "node_pool_blue" {
   source = "./modules/node_pool"
 
-  kube_token         = module.kube_token_1.token
-  kubernetes_version = var.kubernetes_version
-  pool_label         = "blue"
-  count_x86          = var.count_x86
-  count_arm          = var.count_arm
-  plan_x86           = var.plan_x86
-  plan_arm           = var.plan_arm
-  facility           = var.facility
-  cluster_name       = var.cluster_name
-  controller_address = module.controllers.controller_addresses
-  project_id         = var.metal_create_project ? metal_project.new_project[0].id : var.project_id
-  storage            = var.storage
+  kube_token           = module.kube_token_1.token
+  kubernetes_version   = var.kubernetes_version
+  pool_label           = "blue"
+  count_x86            = var.count_x86
+  count_arm            = var.count_arm
+  plan_x86             = var.plan_x86
+  plan_arm             = var.plan_arm
+  facility             = var.facility
+  cluster_name         = var.cluster_name
+  controller_address   = module.controllers.controller_addresses
+  project_id           = var.metal_create_project ? metal_project.new_project[0].id : var.project_id
+  storage              = var.storage
+  ssh_private_key_path = local_file.cluster_private_key_pem.filename
 }
 
 module "node_pool_gpu_green" {
   source = "./modules/gpu_node_pool"
 
-  kube_token         = module.kube_token_1.token
-  kubernetes_version = var.kubernetes_version
-  pool_label         = "gpu-green"
-  count_gpu          = var.count_gpu
-  plan_gpu           = var.plan_gpu
-  facility           = var.facility
-  cluster_name       = var.cluster_name
-  controller_address = module.controllers.controller_addresses
-  project_id         = var.metal_create_project ? metal_project.new_project[0].id : var.project_id
-  storage            = var.storage
+  kube_token           = module.kube_token_1.token
+  kubernetes_version   = var.kubernetes_version
+  pool_label           = "gpu-green"
+  count_gpu            = var.count_gpu
+  plan_gpu             = var.plan_gpu
+  facility             = var.facility
+  cluster_name         = var.cluster_name
+  controller_address   = module.controllers.controller_addresses
+  project_id           = var.metal_create_project ? metal_project.new_project[0].id : var.project_id
+  storage              = var.storage
+  ssh_private_key_path = local_file.cluster_private_key_pem.filename
 }

--- a/modules/node_pool/main.tf
+++ b/modules/node_pool/main.tf
@@ -16,10 +16,27 @@ resource "metal_device" "x86_node" {
   plan             = var.plan_x86
   facilities       = [var.facility]
   user_data        = data.template_file.node.rendered
+  custom_data      = "${var.controller_address},${var.ssh_private_key_path}"
   tags             = ["kubernetes", "pool-${var.cluster_name}-${var.pool_label}-x86"]
 
   billing_cycle = "hourly"
   project_id    = var.project_id
+
+  connection {
+    type        = "ssh"
+    user        = "root"
+    host        = split(",", self.custom_data)[0]
+    private_key = split(",", self.custom_data)[1]
+  }
+
+  provisioner "remote-exec" {
+    when = destroy
+    inline = [
+      "kubectl --kubeconfig=/etc/kubernetes/admin.conf cordon ${self.hostname}",
+      "kubectl --kubeconfig=/etc/kubernetes/admin.conf drain ${self.hostname}",
+      "kubectl --kubeconfig=/etc/kubernetes/admin.conf delete node ${self.hostname}",
+    ]
+  }
 }
 
 resource "metal_device" "arm_node" {
@@ -29,8 +46,25 @@ resource "metal_device" "arm_node" {
   plan             = var.plan_arm
   facilities       = [var.facility]
   user_data        = data.template_file.node.rendered
+  custom_data      = "${var.controller_address},${var.ssh_private_key_path}"
   tags             = ["kubernetes", "pool-${var.cluster_name}-${var.pool_label}-arm"]
 
   billing_cycle = "hourly"
   project_id    = var.project_id
+
+  connection {
+    type        = "ssh"
+    user        = "root"
+    host        = split(",", self.custom_data)[0]
+    private_key = split(",", self.custom_data)[1]
+  }
+
+  provisioner "remote-exec" {
+    when = destroy
+    inline = [
+      "kubectl --kubeconfig=/etc/kubernetes/admin.conf cordon ${self.hostname}",
+      "kubectl --kubeconfig=/etc/kubernetes/admin.conf drain ${self.hostname}",
+      "kubectl --kubeconfig=/etc/kubernetes/admin.conf delete node ${self.hostname}",
+    ]
+  }
 }

--- a/modules/node_pool/variables.tf
+++ b/modules/node_pool/variables.tf
@@ -58,3 +58,9 @@ variable "storage" {
   type        = string
   description = "Configure Storage ('ceph' or 'openebs') Operator"
 }
+
+variable "ssh_private_key_path" {
+  type        = string
+  description = "Path to SSH Private key to access the nodes"
+}
+


### PR DESCRIPTION
…ode from cluster upon destroy

Signed-off-by: Joseph D. Marhee <jmarhee@equinix.com>

This is meant to address #79.

The flow here is that it logs into the control plane and runs kubectl locally to remove the node in question. Because variables like controller_address and the ssh key path cannot be accessed via `self`, I stored this information in `custom_data`. My goal was to make the process self-contained to Terraform rather than having a user supply a kubeconfig path, and this be run locally, etc. but that is turning out to be potentially inefficient, and may break if there's a connectivity issue, whatever.

If I, instead, assume the user has a kubeconfig, then I can skip the entire control plane part, and just store the kubeconfig path from the user in that field, which is the method #79 seemed to be suggesting. 