### PR TITLE
include kubeconfig filename in outputs, make content sensitive

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,6 +14,10 @@ jobs:
     name: Integration Tests
     runs-on: ${{ matrix.os }}
     env:
+      TF_VAR_secrets_encryption: false
+      TF_VAR_metro: "sv"
+      TF_VAR_ccm_enabled: true
+      TF_VAR_loadbalancer_type: "kube-vip"
       TF_IN_AUTOMATION: 1
       TF_VERSION: ${{ matrix.tf }}
       TF_VAR_control_plane_node_count: 0

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 *.tfvars
 examples/inventory.yaml
 examples/main.retry
+kubeconfig
+metal-key
+metal-key.pub

--- a/modules/controller_pool/assets/kubeconfig_copy.sh
+++ b/modules/controller_pool/assets/kubeconfig_copy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 /usr/bin/ssh -i $ssh_private_key_path -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@$controller "while true; do if ! type kubeadm > /dev/null; then sleep 20; else break; fi; done"
-sleep 360
+sleep 520
 /usr/bin/scp -i $ssh_private_key_path -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -q root@$controller:/etc/kubernetes/admin.conf $local_path/kubeconfig;
 

--- a/modules/controller_pool/controller-primary.tpl
+++ b/modules/controller_pool/controller-primary.tpl
@@ -109,10 +109,7 @@ EOF
 
 function kube_vip {
   kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f https://kube-vip.io/manifests/rbac.yaml
-  GATEWAY_IP=$(curl https://metadata.platformequinix.com/metadata | jq -r ".network.addresses[] | select(.public == false) | .gateway");
-  ip route add 169.254.255.1 via $GATEWAY_IP
-  ip route add 169.254.255.2 via $GATEWAY_IP
-  docker run --network host --rm ghcr.io/kube-vip/kube-vip:v0.3.8 manifest daemonset \
+  docker run --network host --rm ghcr.io/kube-vip/kube-vip:v0.4.0 manifest daemonset \
   --interface lo \
   --services \
   --bgp \

--- a/modules/controller_pool/controller-primary.tpl
+++ b/modules/controller_pool/controller-primary.tpl
@@ -108,17 +108,16 @@ EOF
 }
 
 function kube_vip {
-  kubectl apply -f https://kube-vip.io/manifests/rbac.yaml
+  kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f https://kube-vip.io/manifests/rbac.yaml
   GATEWAY_IP=$(curl https://metadata.platformequinix.com/metadata | jq -r ".network.addresses[] | select(.public == false) | .gateway");
   ip route add 169.254.255.1 via $GATEWAY_IP
   ip route add 169.254.255.2 via $GATEWAY_IP
-  alias kube-vip="docker run --network host --rm ghcr.io/kube-vip/kube-vip:v0.3.8"
-  kube-vip manifest daemonset \
+  docker run --network host --rm ghcr.io/kube-vip/kube-vip:v0.3.8 manifest daemonset \
   --interface lo \
   --services \
   --bgp \
   --annotations metal.equinix.com \
-  --inCluster | kubectl apply -f -
+  --inCluster | kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f -
 }
 
 function ceph_pre_check {

--- a/modules/controller_pool/main.tf
+++ b/modules/controller_pool/main.tf
@@ -83,7 +83,7 @@ resource "null_resource" "kubeconfig" {
 }
 
 data "local_file" "kubeconfig" {
-  filename = "${path.root}/kubeconfig"
+  filename = abspath("${path.root}/kubeconfig")
 
   depends_on = [
     null_resource.kubeconfig

--- a/modules/controller_pool/outputs.tf
+++ b/modules/controller_pool/outputs.tf
@@ -9,6 +9,12 @@ output "controller_addresses" {
 # }
 
 output "kubeconfig" {
-  description = "Kubeconfig for the newly created cluster"
-  value       = data.local_file.kubeconfig
+  description = "Kubeconfig content for the newly created cluster"
+  value       = data.local_file.kubeconfig.content
+  sensitive   = true
+}
+
+output "kubeconfig_filename" {
+  description = "Kubeconfig file for the newly created cluster"
+  value       = data.local_file.kubeconfig.filename
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,4 +10,10 @@ output "kubernetes_api_address" {
 output "kubernetes_kubeconfig" {
   description = "Kubeconfig for the newly created cluster"
   value       = module.controllers.kubeconfig
+  sensitive   = true
+}
+
+output "kubernetes_kubeconfig_file" {
+  description = "Kubecobnfig file for the newly created cluster"
+  value       = module.controllers.kubeconfig_filename
 }


### PR DESCRIPTION
Following #93, this PR adds the kubeconfig_filename to the outputs.
The kubeconfig variable is reduced from a structure to the file contents, which are marked sensitive.