### PR TITLE
Fix kube-vip installation steps and increase sleep

### DIFF
--- a/modules/controller_pool/assets/kubeconfig_copy.sh
+++ b/modules/controller_pool/assets/kubeconfig_copy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 /usr/bin/ssh -i $ssh_private_key_path -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@$controller "while true; do if ! type kubeadm > /dev/null; then sleep 20; else break; fi; done"
-sleep 360
+sleep 520
 /usr/bin/scp -i $ssh_private_key_path -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -q root@$controller:/etc/kubernetes/admin.conf $local_path/kubeconfig;
 

--- a/modules/controller_pool/controller-primary.tpl
+++ b/modules/controller_pool/controller-primary.tpl
@@ -108,7 +108,7 @@ EOF
 }
 
 function kube_vip {
-  kubectl apply -f https://kube-vip.io/manifests/rbac.yaml
+  kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f https://kube-vip.io/manifests/rbac.yaml
   GATEWAY_IP=$(curl https://metadata.platformequinix.com/metadata | jq -r ".network.addresses[] | select(.public == false) | .gateway");
   ip route add 169.254.255.1 via $GATEWAY_IP
   ip route add 169.254.255.2 via $GATEWAY_IP
@@ -118,7 +118,7 @@ function kube_vip {
   --services \
   --bgp \
   --annotations metal.equinix.com \
-  --inCluster | kubectl apply -f -
+  --inCluster | kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f -
 }
 
 function ceph_pre_check {

--- a/modules/controller_pool/controller-primary.tpl
+++ b/modules/controller_pool/controller-primary.tpl
@@ -112,8 +112,8 @@ function kube_vip {
   GATEWAY_IP=$(curl https://metadata.platformequinix.com/metadata | jq -r ".network.addresses[] | select(.public == false) | .gateway");
   ip route add 169.254.255.1 via $GATEWAY_IP
   ip route add 169.254.255.2 via $GATEWAY_IP
-  alias kube-vip="docker run --network host --rm ghcr.io/kube-vip/kube-vip:v0.3.8"
-  kube-vip manifest daemonset \
+  alias kube-vip=""
+  docker run --network host --rm ghcr.io/kube-vip/kube-vip:v0.3.8 manifest daemonset \
   --interface lo \
   --services \
   --bgp \

--- a/modules/controller_pool/controller-primary.tpl
+++ b/modules/controller_pool/controller-primary.tpl
@@ -112,7 +112,6 @@ function kube_vip {
   GATEWAY_IP=$(curl https://metadata.platformequinix.com/metadata | jq -r ".network.addresses[] | select(.public == false) | .gateway");
   ip route add 169.254.255.1 via $GATEWAY_IP
   ip route add 169.254.255.2 via $GATEWAY_IP
-  alias kube-vip=""
   docker run --network host --rm ghcr.io/kube-vip/kube-vip:v0.3.8 manifest daemonset \
   --interface lo \
   --services \


### PR DESCRIPTION
Turns out kubevip wasn't being installed (at least in my testing) because of weirdness with the alias command. So I just used the raw docker command