### PR TITLE
use file function for connection private key

### DIFF
--- a/modules/controller_pool/main.tf
+++ b/modules/controller_pool/main.tf
@@ -97,7 +97,7 @@ resource "null_resource" "key_wait_transfer" {
     type        = "ssh"
     user        = "root"
     host        = metal_device.k8s_controller_standby[count.index].access_public_ipv4
-    private_key = var.ssh_private_key_path
+    private_key = file(var.ssh_private_key_path)
     password    = metal_device.k8s_controller_standby[count.index].root_password
   }
 


### PR DESCRIPTION
The private_key in a terraform connection block needs to be the actual key, and not a path to the key. To grab the key from the path the `file()` function is used.