### PR TITLE
Explicitly make the controller module depend on metal_ssh_key

### DIFF
--- a/kubernetes-controller-pool.tf
+++ b/kubernetes-controller-pool.tf
@@ -58,4 +58,8 @@ module "controllers" {
   ssh_private_key_path     = abspath(local_file.cluster_private_key_pem.filename)
   ccm_enabled              = var.ccm_enabled
   loadbalancer_type        = var.loadbalancer_type
+
+  depends_on = [
+    metal_ssh_key.kubernetes-on-metal # if the primary node is created before the metal_ssh_key, then the primary node won't be accessible
+  ]
 }


### PR DESCRIPTION
While working with this module, I ran into a race condition if I added more than 1 data plane node to the cluster. The controller module shouldn't be created until the metal ssh key is