### PR TITLE
Remove provider configuration from module

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        tf: [0.14.10]
+        tf: [0.15.1]
     steps:
     - name: Checkout from Github
       uses: actions/checkout@v2

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -10,3 +10,7 @@ module "multiarch-k8s" {
   auth_token = var.auth_token
   project_id = var.project_id
 }
+
+provider "metal" {
+  auth_token = var.auth_token
+}

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,3 @@
-provider "metal" {
-  auth_token = var.auth_token
-}
-
 resource "metal_project" "new_project" {
   count = var.metal_create_project ? 1 : 0
   name  = var.metal_project_name


### PR DESCRIPTION
Having a `provider` block in a TF module prevents users from using
depends_on, count, or for_each directives when calling the module

Signed-off-by: Keith Mattix II <keithmattix2@gmail.com>