### PR TITLE
Fix containerd installation

### DIFF
--- a/modules/controller_pool/controller-standby.tpl
+++ b/modules/controller_pool/controller-standby.tpl
@@ -3,29 +3,35 @@
 export HOME=/root
 
 function install_containerd() {
-cat <<EOF > /etc/modules-load.d/containerd.conf
+  cat <<EOF > /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
 EOF
- modprobe overlay
- modprobe br_netfilter
- echo "Installing Containerd..."
- apt-get update
- apt-get install -y ca-certificates socat ebtables apt-transport-https cloud-utils prips containerd jq python3
+  modprobe overlay
+  modprobe br_netfilter
+  echo "Installing Containerd..."
+  apt-get update && apt-get install -y gnupg2 software-properties-common apt-transport-https ca-certificates socat ebtables cloud-utils prips jq python3
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+  echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+  apt-get update && apt-get install -y containerd.io
+  # Configure containerd
+  mkdir -p /etc/containerd
+  containerd config default | sudo tee /etc/containerd/config.toml >/dev/null 2>&1
+  sed -i 's/SystemdCgroup \= false/SystemdCgroup \= true/g' /etc/containerd/config.toml
 }
 
 function enable_containerd() {
- systemctl daemon-reload
- systemctl enable containerd
- systemctl start containerd
+  systemctl daemon-reload
+  systemctl restart containerd
+  systemctl enable containerd
 }
 
 function bgp_routes {
-    GATEWAY_IP=$(curl https://metadata.platformequinix.com/metadata | jq -r ".network.addresses[] | select(.public == false) | .gateway")
-    # TODO use metadata peer ips
-    ip route add 169.254.255.1 via $GATEWAY_IP
-    ip route add 169.254.255.2 via $GATEWAY_IP
-    sed -i.bak -E "/^\s+post-down route del -net 10\.0\.0\.0.* gw .*$/a \ \ \ \ up ip route add 169.254.255.1 via $GATEWAY_IP || true\n    up ip route add 169.254.255.2 via $GATEWAY_IP || true\n    down ip route del 169.254.255.1 || true\n    down ip route del 169.254.255.2 || true" /etc/network/interfaces
+  GATEWAY_IP=$(curl https://metadata.platformequinix.com/metadata | jq -r ".network.addresses[] | select(.public == false) | .gateway")
+  # TODO use metadata peer ips
+  ip route add 169.254.255.1 via $GATEWAY_IP
+  ip route add 169.254.255.2 via $GATEWAY_IP
+  sed -i.bak -E "/^\s+post-down route del -net 10\.0\.0\.0.* gw .*$/a \ \ \ \ up ip route add 169.254.255.1 via $GATEWAY_IP || true\n    up ip route add 169.254.255.2 via $GATEWAY_IP || true\n    down ip route del 169.254.255.1 || true\n    down ip route del 169.254.255.2 || true" /etc/network/interfaces
 }
 
 function ceph_pre_check {
@@ -33,13 +39,14 @@ function ceph_pre_check {
   modprobe rbd
 }
 
-function install_kube_tools() {
- swapoff -a  && \
- apt-get update && apt-get install -y apt-transport-https
- curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
- echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
- apt-get update
- apt-get install -y kubelet=${kube_version} kubeadm=${kube_version} kubectl=${kube_version}
+function install_kube_tools {
+  echo "Installing Kubeadm tools..."
+  sed -i '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab
+  swapoff -a
+  curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+  echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+  apt-get update
+  apt-get install -y kubelet=${kube_version} kubeadm=${kube_version} kubectl=${kube_version}
 }
 
 install_containerd && \

--- a/modules/controller_pool/main.tf
+++ b/modules/controller_pool/main.tf
@@ -30,7 +30,7 @@ data "template_file" "controller-primary" {
 
 resource "equinix_metal_device" "k8s_primary" {
   hostname         = "${var.cluster_name}-controller-primary"
-  operating_system = "ubuntu_18_04"
+  operating_system = "ubuntu_22_04"
   plan             = var.plan_primary
   facilities       = var.facility != "" ? [var.facility] : null
   metro            = var.metro != "" ? var.metro : null
@@ -57,7 +57,7 @@ resource "equinix_metal_device" "k8s_controller_standby" {
   depends_on = [equinix_metal_device.k8s_primary]
 
   hostname         = format("${var.cluster_name}-controller-standby-%02d", count.index)
-  operating_system = "ubuntu_18_04"
+  operating_system = "ubuntu_22_04"
   plan             = var.plan_primary
   facilities       = var.facility != "" ? [var.facility] : null
   metro            = var.metro != "" ? var.metro : null

--- a/modules/gpu_node_pool/gpu_node.tpl
+++ b/modules/gpu_node_pool/gpu_node.tpl
@@ -3,10 +3,10 @@
 export HOME=/root
 
 function nvidia_configure() {
- distribution=$(. /etc/os-release;echo $ID$VERSION_ID) ; \
- curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add - ; \
- curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list ; \
- sudo apt-get update && sudo apt-get install -y nvidia-container-runtime nvidia-cuda-toolkit
+  distribution=$(. /etc/os-release;echo $ID$VERSION_ID) ; \
+  curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add - ; \
+  curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list ; \
+  sudo apt-get update && sudo apt-get install -y nvidia-container-runtime nvidia-cuda-toolkit
 }
 
 function nvidia_drivers() {
@@ -23,23 +23,28 @@ function nvidia_drivers() {
 }
 
 function install_containerd() {
-cat <<EOF > /etc/modules-load.d/containerd.conf
+  cat <<EOF > /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
 EOF
- modprobe overlay
- modprobe br_netfilter
- echo "Installing Containerd..."
- apt-get update
- apt-get install -y ca-certificates socat ebtables apt-transport-https cloud-utils prips containerd jq python3
+  modprobe overlay
+  modprobe br_netfilter
+  echo "Installing Containerd..."
+  apt-get update && apt-get install -y gnupg2 software-properties-common apt-transport-https ca-certificates socat ebtables cloud-utils prips jq python3
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+  echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+  apt-get update && apt-get install -y containerd.io
+  # Configure containerd
+  mkdir -p /etc/containerd
+  containerd config default | sudo tee /etc/containerd/config.toml >/dev/null 2>&1
+  sed -i 's/SystemdCgroup \= false/SystemdCgroup \= true/g' /etc/containerd/config.toml
 }
 
 function enable_containerd() {
- systemctl daemon-reload
- systemctl enable containerd
- systemctl start containerd
+  systemctl daemon-reload
+  systemctl restart containerd
+  systemctl enable containerd
 }
-
 
 function ceph_pre_check {
   apt install -y lvm2 ; \
@@ -47,26 +52,33 @@ function ceph_pre_check {
 }
 
 function bgp_routes {
-    GATEWAY_IP=$(curl https://metadata.platformequinix.com/metadata | jq -r ".network.addresses[] | select(.public == false) | .gateway")
-    # TODO use metadata peer ips
-    ip route add 169.254.255.1 via $GATEWAY_IP
-    ip route add 169.254.255.2 via $GATEWAY_IP
-    sed -i.bak -E "/^\s+post-down route del -net 10\.0\.0\.0.* gw .*$/a \ \ \ \ up ip route add 169.254.255.1 via $GATEWAY_IP || true\n    up ip route add 169.254.255.2 via $GATEWAY_IP || true\n    down ip route del 169.254.255.1 || true\n    down ip route del 169.254.255.2 || true" /etc/network/interfaces
+  GATEWAY_IP=$(curl https://metadata.platformequinix.com/metadata | jq -r ".network.addresses[] | select(.public == false) | .gateway")
+  # TODO use metadata peer ips
+  ip route add 169.254.255.1 via $GATEWAY_IP
+  ip route add 169.254.255.2 via $GATEWAY_IP
+  sed -i.bak -E "/^\s+post-down route del -net 10\.0\.0\.0.* gw .*$/a \ \ \ \ up ip route add 169.254.255.1 via $GATEWAY_IP || true\n    up ip route add 169.254.255.2 via $GATEWAY_IP || true\n    down ip route del 169.254.255.1 || true\n    down ip route del 169.254.255.2 || true" /etc/network/interfaces
 }
 
 function install_kube_tools() {
- swapoff -a  && \
- apt-get update && apt-get install -y apt-transport-https
- curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
- echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
- apt-get update
- apt-get install -y kubelet=${kube_version} kubeadm=${kube_version} kubectl=${kube_version}
- echo "Waiting 180s to attempt to join cluster..."
+  sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+  swapoff -a
+  curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+  echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+  apt-get update
+  apt-get install -y kubelet=${kube_version} kubeadm=${kube_version} kubectl=${kube_version}
+  echo "Waiting 180s to attempt to join cluster..."
 }
 
 function join_cluster() {
-	echo "Attempting to join cluster" && \
-    kubeadm join "${primary_node_ip}:6443" --token "${kube_token}" --discovery-token-unsafe-skip-ca-verification
+	echo "Attempting to join cluster"
+  tee /etc/sysctl.d/kubernetes.conf <<EOF
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1
+net.ipv4.ip_forward = 1
+EOF
+
+  sysctl --system
+  kubeadm join "${primary_node_ip}:6443" --token "${kube_token}" --discovery-token-unsafe-skip-ca-verification
 }
 
 install_containerd && \

--- a/modules/gpu_node_pool/main.tf
+++ b/modules/gpu_node_pool/main.tf
@@ -12,7 +12,7 @@ data "template_file" "gpu_node" {
 
 resource "equinix_metal_device" "gpu_node" {
   hostname         = format("${var.cluster_name}-gpu-${var.pool_label}-%02d", count.index)
-  operating_system = "ubuntu_18_04"
+  operating_system = "ubuntu_22_04"
   count            = var.count_gpu
   plan             = var.plan_gpu
   facilities       = var.facility != "" ? [var.facility] : null

--- a/modules/node_pool/main.tf
+++ b/modules/node_pool/main.tf
@@ -12,7 +12,7 @@ data "template_file" "node" {
 
 resource "equinix_metal_device" "x86_node" {
   hostname         = format("${var.cluster_name}-x86-${var.pool_label}-%02d", count.index)
-  operating_system = "ubuntu_18_04"
+  operating_system = "ubuntu_22_04"
   count            = var.count_x86
   plan             = var.plan_x86
   facilities       = var.facility != "" ? [var.facility] : null
@@ -26,7 +26,7 @@ resource "equinix_metal_device" "x86_node" {
 
 resource "equinix_metal_device" "arm_node" {
   hostname         = format("${var.cluster_name}-arm-${var.pool_label}-%02d", count.index)
-  operating_system = "ubuntu_18_04"
+  operating_system = "ubuntu_22_04"
   count            = var.count_arm
   plan             = var.plan_arm
   facilities       = var.facility != "" ? [var.facility] : null

--- a/modules/node_pool/node.tpl
+++ b/modules/node_pool/node.tpl
@@ -2,23 +2,28 @@
 
 export HOME=/root
 
-
 function install_containerd() {
-cat <<EOF > /etc/modules-load.d/containerd.conf
+  cat <<EOF > /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter
 EOF
- modprobe overlay
- modprobe br_netfilter
- echo "Installing Containerd..."
- apt-get update
- apt-get install -y ca-certificates socat ebtables apt-transport-https cloud-utils prips containerd jq python3
+  modprobe overlay
+  modprobe br_netfilter
+  echo "Installing Containerd..."
+  apt-get update && apt-get install -y gnupg2 software-properties-common apt-transport-https ca-certificates socat ebtables cloud-utils prips jq python3
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+  echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+  apt-get update && apt-get install -y containerd.io
+  # Configure containerd
+  mkdir -p /etc/containerd
+  containerd config default | sudo tee /etc/containerd/config.toml >/dev/null 2>&1
+  sed -i 's/SystemdCgroup \= false/SystemdCgroup \= true/g' /etc/containerd/config.toml
 }
 
 function enable_containerd() {
- systemctl daemon-reload
- systemctl enable containerd
- systemctl start containerd
+  systemctl daemon-reload
+  systemctl restart containerd
+  systemctl enable containerd
 }
 
 function ceph_pre_check {
@@ -27,29 +32,29 @@ function ceph_pre_check {
 }
 
 function bgp_routes {
-    GATEWAY_IP=$(curl https://metadata.platformequinix.com/metadata | jq -r ".network.addresses[] | select(.public == false) | .gateway")
-    # TODO use metadata peer ips
-    ip route add 169.254.255.1 via $GATEWAY_IP
-    ip route add 169.254.255.2 via $GATEWAY_IP
-    sed -i.bak -E "/^\s+post-down route del -net 10\.0\.0\.0.* gw .*$/a \ \ \ \ up ip route add 169.254.255.1 via $GATEWAY_IP || true\n    up ip route add 169.254.255.2 via $GATEWAY_IP || true\n    down ip route del 169.254.255.1 || true\n    down ip route del 169.254.255.2 || true" /etc/network/interfaces
+  GATEWAY_IP=$(curl https://metadata.platformequinix.com/metadata | jq -r ".network.addresses[] | select(.public == false) | .gateway")
+  # TODO use metadata peer ips
+  ip route add 169.254.255.1 via $GATEWAY_IP
+  ip route add 169.254.255.2 via $GATEWAY_IP
+  sed -i.bak -E "/^\s+post-down route del -net 10\.0\.0\.0.* gw .*$/a \ \ \ \ up ip route add 169.254.255.1 via $GATEWAY_IP || true\n    up ip route add 169.254.255.2 via $GATEWAY_IP || true\n    down ip route del 169.254.255.1 || true\n    down ip route del 169.254.255.2 || true" /etc/network/interfaces
 }
 
 function install_kube_tools() {
- swapoff -a  && \
- apt-get update && apt-get install -y apt-transport-https
- curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
- echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
- apt-get update
- apt-get install -y kubelet=${kube_version} kubeadm=${kube_version} kubectl=${kube_version}
- echo "Waiting 180s to attempt to join cluster..."
+  sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+  swapoff -a
+  curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+  echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+  apt-get update
+  apt-get install -y kubelet=${kube_version} kubeadm=${kube_version} kubectl=${kube_version}
+  echo "Waiting 180s to attempt to join cluster..."
 }
 
 function join_cluster() {
 	echo "Attempting to join cluster"
-  cat <<EOF > /etc/sysctl.d/99-kubernetes-cri.conf
-net.bridge.bridge-nf-call-iptables  = 1
-net.ipv4.ip_forward                 = 1
+  tee /etc/sysctl.d/kubernetes.conf <<EOF
 net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1
+net.ipv4.ip_forward = 1
 EOF
 
   sysctl --system

--- a/variables.tf
+++ b/variables.tf
@@ -111,7 +111,7 @@ variable "workloads" {
   description = "Workloads to apply on provisioning (multiple manifests for a single key should be a comma-separated string)"
   default = {
     cni_cidr             = "192.168.0.0/16"
-    cni_workloads        = "https://projectcalico.docs.tigera.io/archive/v3.24/manifests/tigera-operator.yaml,https://projectcalico.docs.tigera.io/archive/v3.24/manifests/custom-resources.yaml"
+    cni_workloads        = "https://projectcalico.docs.tigera.io/archive/v3.25/manifests/tigera-operator.yaml,https://projectcalico.docs.tigera.io/archive/v3.25/manifests/custom-resources.yaml"
     ceph_common          = "https://raw.githubusercontent.com/rook/rook/release-1.0/cluster/examples/kubernetes/ceph/common.yaml"
     ceph_operator        = "https://raw.githubusercontent.com/rook/rook/release-1.0/cluster/examples/kubernetes/ceph/operator.yaml"
     ceph_cluster_minimal = "https://raw.githubusercontent.com/rook/rook/release-1.0/cluster/examples/kubernetes/ceph/cluster-minimal.yaml"


### PR DESCRIPTION
The installation has recently started to fail. Replacing containerd with docker containerd.io package fixes this issue.

```
[preflight] Running pre-flight checks
error execution phase preflight: [preflight] Some fatal errors occurred:
        [ERROR CRI]: container runtime is not running: output: time="2023-01-25T15:55:02Z" level=fatal msg="validate service connection: CRI v1 runtime API is not implemented for endpoint \"unix:///var/run/containerd/containerd.sock\": rpc error: code = Unimplemented desc = unknown service runtime.v1.RuntimeService"
, error: exit status 1
```

Actions:

- Replace containerd incuded in default ubuntu repo with containerd.io from docker repo
- Upgrade ubuntu to 22.04
- Upgrade tigera to v3.25

Kubernetes cannot be upgraded to 1.25+ until metallb is upgraded to 0.13+